### PR TITLE
Unify fonts and finalize visual fixes

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,6 +5,12 @@ search: false
 
 @charset "utf-8";
 
+// Font Overrides - Unify font family
+$sans-serif: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", Arial, sans-serif;
+$global-font-family: $sans-serif;
+$header-font-family: $sans-serif;
+$caption-font-family: $sans-serif;
+
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
 


### PR DESCRIPTION
- `assets/css/main.scss`:
  - Defined `$sans-serif` and set `$global-font-family`, `$header-font-family`, and `$caption-font-family` to use it.
  - This ensures a consistent font look across the entire site (main content, sidebar, etc.).
  - Preserved profile picture overrides.
- This commit also includes previous fixes for the profile picture (square crop, responsive CSS) and the addition of the "Hire Me" section.