### PR TITLE
Remove RSS feed and finalize site updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,7 +84,6 @@ plugins:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist
-  - jekyll-feed
   - jemoji
   - jekyll-include-cache
 


### PR DESCRIPTION
- Removed `jekyll-feed` from `_config.yml` to disable RSS feed generation.
- Previous changes included:
  - Fixes for profile picture (square, responsive).
  - Addition of "Hire Me?" page and navigation.
  - Unification of fonts across the site.
  - Refinement of "About Me" page.